### PR TITLE
add tomli-w 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,13 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     # We cannot use flit-core >=3.2.0,<4
     # b/c we need to avoid a cyclic dependency on tomli-w
     - flit-core 3.3.0
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.7
 
@@ -37,7 +39,10 @@ about:
   home: https://pypi.org/project/tomli_w/
   summary: A lil' TOML writer
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/hukkin/tomli-w
+  doc_url: https://github.com/hukkin/tomli-w/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
flit-core 3.6.0 requires tomli-w

Changelog: https://github.com/hukkin/tomli-w/blob/master/CHANGELOG.md
Bug tracker: https://github.com/hukkin/tomli-w/issues
License: https://github.com/hukkin/tomli-w/blob/1.0.0/LICENSE
Requirements: https://github.com/hukkin/tomli-w/blob/1.0.0/pyproject.toml


Actions:
1. Fix `python `in `host`.
2. Add missing host dependencies `setuptools` and `wheel`
3. Add licende_family, dev and doc urls